### PR TITLE
Disable flake8 supported plugins in pyls

### DIFF
--- a/pyls_flake8/plugin.py
+++ b/pyls_flake8/plugin.py
@@ -114,6 +114,19 @@ def pyls_lint(config, document):
     return results_to_diagnostic(p.stdout.decode(), document)
 
 
+@hookimpl
+def pyls_settings():
+    """
+    Disable all plugins which are supported by flake8
+    """
+    config = {'plugins': {
+        'pycodestyle': {'enabled': False},
+        'mccabe': {'enabled': False},
+        'pyflakes': {'enabled': False}
+    }}
+    return config
+
+
 if __name__ == "__main__":
     class test_document:
         def __init__(self, src: str):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ desc = "Flake8 plugin for the Python Language Server"
 
 setup(
       name="pyls-flake8",
-      version="0.1.0",
+      version="0.2.0",
       description=desc,
       long_description=desc,
       url="https://github.com/emanspeaks/pyls-flake8",


### PR DESCRIPTION
When installing this plugin pycodestyle and pyflakes remain active when flake8 is used. 
This results in duplicated errors and configuration not being respected (as you only define it for flake8). 
The changes provided in this pull request should fix that. It disables the plugins which are supported through flake8 by default so pyls does not use them directly.

This makes the default more predictable and it avoids the need to change the configuration through the editor configuration.

I also upgraded the version number so it becomes clear that a change has been made which may change the behavior. 