### PR TITLE
Depend on python-lsp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # pyls-flake8
 
 A Flake8 plugin for the
-[Python Language Server](https://github.com/palantir/python-language-server).
+[Python LSP Server](https://github.com/python-lsp/python-lsp-server).
 
-Install this plugin in the same environment as `python-language-server`:
+Install this plugin in the same environment as `python-lsp-server`:
 
 ```shell
 pip install pyls-flake8

--- a/pyls_flake8/plugin.py
+++ b/pyls_flake8/plugin.py
@@ -1,6 +1,6 @@
 import re
 
-from pyls import hookimpl, lsp
+from pylsp import hookimpl, lsp
 
 # default ignored by Flake8 package:
 # E121, continuation line under-indented for hanging indent
@@ -122,7 +122,7 @@ def run_flake8(args, document):
 
 
 @hookimpl(tryfirst=True)
-def pyls_lint(config, document):
+def pylsp_lint(config, document):
     args = compile_flake8_args(config)
     p = run_flake8(args, document)
     stderr = p.stderr.decode()
@@ -132,7 +132,7 @@ def pyls_lint(config, document):
 
 
 @hookimpl
-def pyls_settings():
+def pylsp_settings():
     """
     Disable all plugins which are supported by flake8
     """

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     author="Randy Eckman",
     author_email="emanspeaks@gmail.com",
     packages=find_packages(),
-    install_requires=["python-language-server", "flake8>=3.6.0"],
-    entry_points={"pyls": ["pyls_flake8 = pyls_flake8.plugin"]},
+    install_requires=["python-lsp-server", "flake8>=3.6.0"],
+    entry_points={"pylsp": ["pyls_flake8 = pyls_flake8.plugin"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
[Palantir's python-language-server](https://github.com/palantir/python-language-server) is now unmaintained. [python-lsp-server](https://github.com/python-lsp/python-lsp-server) is a community-maintained fork.

Fixes #6.