### PR TITLE
Fix some problems in config parsing

### DIFF
--- a/pyls_flake8/plugin.py
+++ b/pyls_flake8/plugin.py
@@ -95,13 +95,27 @@ def return_error(stderr: str):
     ]
 
 
+camelcase_snakecase_mapping = {
+    "maxLineLength": "max-line-length",
+    "hangClosing": "hang-closing",
+    "perFileIgnores": "per-file-ignores",
+}
+
+
+def to_snake_case(option):
+    if option in camelcase_snakecase_mapping:
+        return camelcase_snakecase_mapping[option]
+
+    return option
+
+
 def compile_flake8_args(config):
     args = ["flake8"]
     for key, val in config.plugin_settings("flake8").items():
         if key == "enabled":
             continue
-        elif key == "maxLineLength":
-            key = "max-line-length"
+
+        key = to_snake_case(key)
         arg = "--" + key
 
         if val and val is not True:

--- a/pyls_flake8/plugin.py
+++ b/pyls_flake8/plugin.py
@@ -118,12 +118,18 @@ def compile_flake8_args(config):
         key = to_snake_case(key)
         arg = "--" + key
 
-        if val and val is not True:
-            if isinstance(val, list):
-                val = ",".join(val)
-                arg += f"={val}"
-            else:
-                arg += f"={val}"
+        if val is None:
+            continue
+
+        if isinstance(val, list):
+            val = ",".join(val)
+            arg += f"={val}"
+        elif isinstance(val, bool):
+            if not val:
+                continue
+        else:
+            arg += f"={val}"
+
         args.append(arg)
     args.append("-")
     return args


### PR DESCRIPTION
These commits fix the mismatch in configuration names: in python-lsp-server they are camel case, while flake8 accepts them as snake case names.

Moreover a bug in boolean option parsing is fixed.