### PR TITLE
Force default format and ignore lines that doesn't match

### DIFF
--- a/pyls_flake8/plugin.py
+++ b/pyls_flake8/plugin.py
@@ -48,8 +48,9 @@ error = severity_enum.Error
 def results_to_diagnostic(results: str, document):
     diaglist = list()
     for line in results.splitlines():
-        if line:
-            linestr, col, code, msg = result_re.match(line).groups()
+        match = result_re.match(line)
+        if match:
+            linestr, col, code, msg = match.groups()
 
             lineno = int(linestr) - 1
             offset = int(col) - 1

--- a/pyls_flake8/plugin.py
+++ b/pyls_flake8/plugin.py
@@ -131,7 +131,7 @@ def compile_flake8_args(config):
             arg += f"={val}"
 
         args.append(arg)
-    args.append("-")
+    args += ["--format", "default", "-"]
     return args
 
 


### PR DESCRIPTION
If `format` is set in a flake8 configuration file enabled with `pylsp.plugins.flake8.config`, it can cause `result_re.match(line)` to return `None` (non-match), which will raise `AttributeError: 'NoneType' object has no attribute 'groups'`.

With this change such configuration will be allowed, but ignored, by appending `--format default` as argument to flake8.
Additionally, to allow for some other configuration that produces non-matches such as `--statistics` and `--show-source`, `result_re.match(line)` will be checked instead of `line` while iterating the results.

A different approach would be to either keep a seperate configuration file to use with python-lsp-server, or to configure `pylsp.plugins.flake8.format = 'default'` (which is not documented in [python-lsp-server configuration](https://github.com/python-lsp/python-lsp-server/blob/develop/CONFIGURATION.md)). In that case I think it would be helpful to return an error, or mention it somewhere in documentation.